### PR TITLE
fix: infinite session crash

### DIFF
--- a/src/angular/modules/infiniteSession.js
+++ b/src/angular/modules/infiniteSession.js
@@ -9,10 +9,8 @@ function keepAlive() {
   console.debug("[infiniteSession] next token refresh in", timer / 1000, "s");
   sessionRefreshTimeout = setTimeout(() => {
     utils.refreshToken();
-    document
-      .querySelector("body")
-      .dispatchEvent(new Event("mousedown", { bubbles: true }))
-      .dispatchEvent(new Event("mouseup", { bubbles: true }));
+    document.body.dispatchEvent(new Event("mousedown", { bubbles: true }))
+    document.body.dispatchEvent(new Event("up", { bubbles: true }))
     keepAlive();
   }, timer);
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7178a6a3-814b-4a4d-aab3-17ba2f79cf73)

After refreshing the token for the first time, the timeout crashed which prevented scheduling the next token refresh. (`dispatchEvent` can't be chained as it returns a boolean, not the element it was called on)

After this change token refreshes happen, but at one point it starts getting 401. ~~For some reason I'm still logged in after 30 minutes of mostly inactivity. Maybe we don't even need to refresh the token and sending some mouse events is enough?~~ Only the 2 minute logout notification is gone, navigating on the site logs me out.

![image](https://github.com/user-attachments/assets/aca6bdc7-ff17-4e91-ae1c-f2e58028bfac)
