### PR TITLE
feat(angular): remember which dashboard widgets were opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A program **felturbózza a Neptun-odat**: gyorsabb tárgy- és vizsgafelvétel, 
 > Ez a fork egy work-in-progress, így nem fog minden tökéletesen működni.
 > Egyenlőre az implementált modulok a következőek az új Neptun felületén:
 >
-> `autoLogin, addVersion, removeTodoBanner, infiniteSession`
+> `autoLogin, addVersion, removeTodoBanner, infiniteSession, rememberDashboardWidgets`
 >
 > Az egyetlen tesztelt felület egyenlőre az [Óbudai Egyetem](https://neptun.uni-obuda.hu/ujhallgato/) új Neptun felülete.
 > Testers welcome!
@@ -127,11 +127,17 @@ Eleged van abból, hogy minden egyes alkalommal be kell állítanod, hogy 500 el
 
 ## Újdonságok
 
+#### 2025. május 11.
+
+- #### Angular
+  - **Újdonság:** Az új felület kezdőoldalán az NPU megjegyzi melyik widgeteket (Pl. Vizsgák, Közelgő események) nyitottad ki.
+
 #### 2025. március 31.
 
 - #### Angular
   - **Újdonság:** Az új felületen mostantól nem dob ki a rendszer 5-10 perc után. 🎉
   - **Javítva:** NPU nem töltött be, ha a kezdő URL nem tartalmazta a jelenlegi oldalt. (Pl. https://url/hallgato nem töltötte be az NPU-t)
+
 #### 2025. március 27.
 
 - #### Angular

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,7 @@ export default defineConfig([globalIgnores(["**/*.js", "**/*.mjs", "!src/**/*.js
         "one-var": ["error", "never"],
         "prefer-const": "error",
         "prefer-template": "error",
+        "semi": ["error", "always"],
         radix: "error",
     },
 }]);

--- a/src/angular/index.js
+++ b/src/angular/index.js
@@ -7,6 +7,7 @@ const modules = [
   require("./modules/addVersion"),
   require("./modules/removeTodoBanner"),
   require("./modules/infiniteSession"),
+  require("./modules/rememberDashboardWidgets"),
 ];
 
 let loadedModules = [];

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -10,8 +10,8 @@ function isOnDashboard() {
 }
 
 async function getWidgets() {
-  return new Promise((resolve) => {
-    function checkWidgets() {
+  return new Promise((resolve, reject) => {
+    function checkWidgets(attempts = 0) {
       // Root elements of Upcoming events, Exams, Messages...
       const widgetRoots = $(".widget");
 
@@ -23,7 +23,11 @@ async function getWidgets() {
 
       // In case the widgets were not loaded yet, try again later
       if (widgets.length === 0) {
-        setTimeout(checkWidgets, 100);
+        const maxAttempts = 100;
+        if (attempts === maxAttempts) {
+          reject(new Error("[rememberDashboardWidgets] failed to find widgets"));
+        }
+        setTimeout(() => checkWidgets(attempts + 1), 50);
         return
       }
 

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -60,9 +60,9 @@ async function loadWidgetStates() {
         $(this).click();
       }
     });
-  })
+  });
 
-  console.debug("[rememberDashboardWidgets] loaded open widgets:", openWidgets)
+  console.debug("[rememberDashboardWidgets] loaded open widgets:", openWidgets);
 }
 
 async function saveOpenWidgets() {
@@ -79,7 +79,7 @@ async function saveOpenWidgets() {
     .get();
 
   storage.setForUser("dashboardOpenWidgets", openWidgets);
-  console.debug("[rememberDashboardWidgets] saved open widgets:", openWidgets)
+  console.debug("[rememberDashboardWidgets] saved open widgets:", openWidgets);
 }
 
 async function init() {
@@ -101,4 +101,4 @@ module.exports = {
   initialize: init,
   // Do actions before destroying
   destroy,
-}
+};

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -1,0 +1,68 @@
+const identifier = ["angular", "rememberDashboardWidgets"];
+
+const $ = window.jQuery;
+const utils = require("../utils");
+const storage = require("../../shared/storage");
+
+function isOnDashboard() {
+  const uri = utils.getCurrentPage().pathname.split("/");
+  return uri[uri.length - 1] === "dashboard";
+}
+
+function getWidgets() {
+  // Root elements of Upcoming events, Exams, Messages...
+  const widgetRoots = $(".widget");
+
+  // Areas of the widgets that
+  // - are clickable
+  // - have an ID that is hopefully stable
+  // - have a class that indicates if it is open or closed (mat-expanded)
+  return widgetRoots.find("mat-expansion-panel-header");
+}
+
+function loadWidgetStates() {
+  const openWidgets = storage.getForUser("dashboardOpenWidgets");
+  if (!openWidgets) {
+    return;
+  }
+
+  const widgets = getWidgets();
+  openWidgets.forEach(widgetId => {
+    const widget = widgets.filter(`#${widgetId}`);
+    widget.click();
+  })
+
+  console.debug("[rememberDashboardWidgets] loaded open widgets:", openWidgets)
+}
+
+function saveOpenWidgets() {
+  const openWidgets = getWidgets()
+    .filter(function() {
+      return $(this).hasClass("mat-expanded");
+    })
+    .map(function() {
+      return $(this).attr("id");
+    })
+    .get();
+
+  storage.setForUser("dashboardOpenWidgets", openWidgets);
+  console.debug("[rememberDashboardWidgets] saved open widgets:", openWidgets)
+}
+
+function init() {
+  loadWidgetStates()
+  getWidgets().on("click", saveOpenWidgets);
+}
+
+function destroy() {
+  getWidgets().off("click", saveOpenWidgets);
+}
+
+module.exports = {
+  identifier: identifier.join("."),
+  shouldActivate: isOnDashboard,
+  shouldNotDestroy: isOnDashboard,
+  initialize: init,
+  // Do actions before destroying
+  destroy,
+}

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -26,9 +26,10 @@ async function getWidgets() {
         const maxAttempts = 100;
         if (attempts === maxAttempts) {
           reject(new Error("[rememberDashboardWidgets] failed to find widgets"));
+          return;
         }
         setTimeout(() => checkWidgets(attempts + 1), 50);
-        return
+        return;
       }
 
       resolve(widgets);

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -27,9 +27,13 @@ function loadWidgetStates() {
   }
 
   const widgets = getWidgets();
-  openWidgets.forEach(widgetId => {
-    const widget = widgets.filter(`#${widgetId}`);
-    widget.click();
+  openWidgets.forEach(widgetTitle => {
+    widgets.each(function() {
+      const titleElement = $(this).find(".widget__title");
+      if (titleElement.text().trim() === widgetTitle) {
+        $(this).click();
+      }
+    });
   })
 
   console.debug("[rememberDashboardWidgets] loaded open widgets:", openWidgets)
@@ -41,7 +45,9 @@ function saveOpenWidgets() {
       return $(this).hasClass("mat-expanded");
     })
     .map(function() {
-      return $(this).attr("id");
+      // Use the widget's title as an identifier because the widget's ID is unreliable
+      // As a downside remembered widgets will be forgotten when the user switches languages
+      return $(this).find(".widget__title").text().trim();
     })
     .get();
 

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -4,12 +4,18 @@ const $ = window.jQuery;
 const utils = require("../utils");
 const storage = require("../../shared/storage");
 
+let cachedWidgets = null;
+
 function isOnDashboard() {
   const uri = utils.getCurrentPage().pathname.split("/");
   return uri[uri.length - 1] === "dashboard";
 }
 
 async function getWidgets() {
+  if (cachedWidgets) {
+    return cachedWidgets;
+  }
+
   return new Promise((resolve, reject) => {
     function checkWidgets(attempts = 0) {
       // Root elements of Upcoming events, Exams, Messages...
@@ -32,6 +38,7 @@ async function getWidgets() {
         return;
       }
 
+      cachedWidgets = widgets;
       resolve(widgets);
     }
 
@@ -84,6 +91,7 @@ async function init() {
 async function destroy() {
   const widgets = await getWidgets();
   widgets.off("click", saveOpenWidgets);
+  cachedWidgets = null;
 }
 
 module.exports = {

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -23,7 +23,7 @@ async function getWidgets() {
 
       // Areas of the widgets that
       // - are clickable
-      // - have an ID that is hopefully stable
+      // - have a child element who's text can be used for identification (widget__title class)
       // - have a class that indicates if it is open or closed (mat-expanded)
       const widgets = widgetRoots.find("mat-expansion-panel-header");
 

--- a/src/angular/modules/rememberDashboardWidgets.js
+++ b/src/angular/modules/rememberDashboardWidgets.js
@@ -9,24 +9,38 @@ function isOnDashboard() {
   return uri[uri.length - 1] === "dashboard";
 }
 
-function getWidgets() {
-  // Root elements of Upcoming events, Exams, Messages...
-  const widgetRoots = $(".widget");
+async function getWidgets() {
+  return new Promise((resolve) => {
+    function checkWidgets() {
+      // Root elements of Upcoming events, Exams, Messages...
+      const widgetRoots = $(".widget");
 
-  // Areas of the widgets that
-  // - are clickable
-  // - have an ID that is hopefully stable
-  // - have a class that indicates if it is open or closed (mat-expanded)
-  return widgetRoots.find("mat-expansion-panel-header");
+      // Areas of the widgets that
+      // - are clickable
+      // - have an ID that is hopefully stable
+      // - have a class that indicates if it is open or closed (mat-expanded)
+      const widgets = widgetRoots.find("mat-expansion-panel-header");
+
+      // In case the widgets were not loaded yet, try again later
+      if (widgets.length === 0) {
+        setTimeout(checkWidgets, 100);
+        return
+      }
+
+      resolve(widgets);
+    }
+
+    checkWidgets();
+  });
 }
 
-function loadWidgetStates() {
+async function loadWidgetStates() {
   const openWidgets = storage.getForUser("dashboardOpenWidgets");
   if (!openWidgets) {
     return;
   }
 
-  const widgets = getWidgets();
+  const widgets = await getWidgets();
   openWidgets.forEach(widgetTitle => {
     widgets.each(function() {
       const titleElement = $(this).find(".widget__title");
@@ -39,8 +53,9 @@ function loadWidgetStates() {
   console.debug("[rememberDashboardWidgets] loaded open widgets:", openWidgets)
 }
 
-function saveOpenWidgets() {
-  const openWidgets = getWidgets()
+async function saveOpenWidgets() {
+  const widgets = await getWidgets();
+  const openWidgets = widgets
     .filter(function() {
       return $(this).hasClass("mat-expanded");
     })
@@ -55,13 +70,15 @@ function saveOpenWidgets() {
   console.debug("[rememberDashboardWidgets] saved open widgets:", openWidgets)
 }
 
-function init() {
-  loadWidgetStates()
-  getWidgets().on("click", saveOpenWidgets);
+async function init() {
+  await loadWidgetStates();
+  const widgets = await getWidgets();
+  widgets.on("click", saveOpenWidgets);
 }
 
-function destroy() {
-  getWidgets().off("click", saveOpenWidgets);
+async function destroy() {
+  const widgets = await getWidgets();
+  widgets.off("click", saveOpenWidgets);
 }
 
 module.exports = {


### PR DESCRIPTION
The widgets on the dashboard like Exams, Upcoming events, Messages are a nice feature from Neptun, but having to reopen them every time when you log in is inconvenient.

This PR adds a module that automatically opens the widgets that were open last time. Whenever the user opens or closes a widget, the list of open widgets will be saved to the storage. Upon loading the dashboard page, the list of open widgets gets retrieved from the storage and the script finds and clicks those widgets to open them.